### PR TITLE
refactor: improve performance

### DIFF
--- a/src/main/java/com/afkspot/afkspotConfig.java
+++ b/src/main/java/com/afkspot/afkspotConfig.java
@@ -3,6 +3,7 @@ package com.afkspot;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("afkspot")
 public interface afkspotConfig extends Config
@@ -13,6 +14,7 @@ public interface afkspotConfig extends Config
 			description = "The number of top NPC density tiles to display (1, 2, or 3)",
 			position = 1
 	)
+	@Range(min = 1)
 	default int numberOfTiles()
 	{
 		return 3;

--- a/src/main/java/com/afkspot/afkspotOverlay.java
+++ b/src/main/java/com/afkspot/afkspotOverlay.java
@@ -9,15 +9,17 @@ import net.runelite.client.ui.overlay.*;
 
 import javax.inject.Inject;
 import java.awt.*;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 public class afkspotOverlay extends Overlay
 {
     private final Client client;
     private final afkspotPlugin plugin;
     @Getter
-    private final Map<WorldPoint, Integer> topTiles = new HashMap<>();
+    private Collection<Map.Entry<WorldPoint, Set<Integer>>> topTiles = Collections.emptyList();
 
     @Inject
     public afkspotOverlay(Client client, afkspotPlugin plugin)
@@ -31,7 +33,7 @@ public class afkspotOverlay extends Overlay
     @Override
     public Dimension render(Graphics2D graphics)
     {
-        for (Map.Entry<WorldPoint, Integer> entry : topTiles.entrySet())
+        for (Map.Entry<WorldPoint, Set<Integer>> entry : topTiles)
         {
             WorldPoint worldPoint = entry.getKey();
             if (client.getPlane() != worldPoint.getPlane())
@@ -45,13 +47,18 @@ public class afkspotOverlay extends Overlay
                 Polygon tilePoly = Perspective.getCanvasTilePoly(client, localPoint);
                 if (tilePoly != null)
                 {
-                    Color color = getColorForDensity(entry.getValue());
+                    Color color = getColorForDensity(entry.getValue().size());
                     OverlayUtil.renderPolygon(graphics, tilePoly, color);
                 }
             }
         }
 
         return null;
+    }
+
+    public void updateTopTiles(Collection<Map.Entry<WorldPoint, Set<Integer>>> tiles)
+    {
+        this.topTiles = tiles;
     }
 
     private Color getColorForDensity(int density)

--- a/src/main/java/com/afkspot/afkspotOverlay.java
+++ b/src/main/java/com/afkspot/afkspotOverlay.java
@@ -1,6 +1,5 @@
 package com.afkspot;
 
-import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.coords.LocalPoint;
@@ -18,14 +17,14 @@ public class afkspotOverlay extends Overlay
 {
     private final Client client;
     private final afkspotPlugin plugin;
-    @Getter
-    private Collection<Map.Entry<WorldPoint, Set<Integer>>> topTiles = Collections.emptyList();
+    private Collection<Map.Entry<WorldPoint, Set<Integer>>> topTiles;
 
     @Inject
     public afkspotOverlay(Client client, afkspotPlugin plugin)
     {
         this.client = client;
         this.plugin = plugin;
+        this.topTiles = Collections.emptyList();
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
     }
@@ -56,9 +55,9 @@ public class afkspotOverlay extends Overlay
         return null;
     }
 
-    public void updateTopTiles(Collection<Map.Entry<WorldPoint, Set<Integer>>> tiles)
+    public void updateTopTiles(Collection<Map.Entry<WorldPoint, Set<Integer>>> topTiles)
     {
-        this.topTiles = tiles;
+        this.topTiles = topTiles;
     }
 
     private Color getColorForDensity(int density)

--- a/src/main/java/com/afkspot/afkspotOverlay.java
+++ b/src/main/java/com/afkspot/afkspotOverlay.java
@@ -1,5 +1,6 @@
 package com.afkspot;
 
+import lombok.Getter;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.coords.LocalPoint;
@@ -15,14 +16,14 @@ public class afkspotOverlay extends Overlay
 {
     private final Client client;
     private final afkspotPlugin plugin;
-    private Map<WorldPoint, Integer> topTiles;
+    @Getter
+    private final Map<WorldPoint, Integer> topTiles = new HashMap<>();
 
     @Inject
     public afkspotOverlay(Client client, afkspotPlugin plugin)
     {
         this.client = client;
         this.plugin = plugin;
-        this.topTiles = new HashMap<>();
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);
     }
@@ -51,11 +52,6 @@ public class afkspotOverlay extends Overlay
         }
 
         return null;
-    }
-
-    public void updateTopTiles(Map<WorldPoint, Integer> topTiles)
-    {
-        this.topTiles = topTiles;
     }
 
     private Color getColorForDensity(int density)

--- a/src/main/java/com/afkspot/afkspotPlugin.java
+++ b/src/main/java/com/afkspot/afkspotPlugin.java
@@ -71,12 +71,18 @@ public class afkspotPlugin extends Plugin
 			return;
 		}
 
-		for (NPC npc : client.getNpcs())
+		NPC[] npcs = client.getCachedNPCs();
+		int n = npcs.length;
+		for (int index = 0; index < n; index++)
 		{
+			NPC npc = npcs[index];
+			if (npc == null || npc.isDead())
+			{
+				continue;
+			}
+
 			WorldPoint npcTile = npc.getWorldLocation();
-			int npcIndex = npc.getIndex();
-			tileDensity.putIfAbsent(npcTile, new HashSet<>());
-			tileDensity.get(npcTile).add(npcIndex);
+			tileDensity.computeIfAbsent(npcTile, k -> new HashSet<>()).add(index);
 		}
 
 		overlay.updateTopTiles(getTopTiles(config.numberOfTiles()));

--- a/src/main/java/com/afkspot/afkspotPlugin.java
+++ b/src/main/java/com/afkspot/afkspotPlugin.java
@@ -57,7 +57,7 @@ public class afkspotPlugin extends Plugin
 	{
 		log.info("AFK Spot Finder stopped!");
 		tileDensity.clear();
-		overlay.getTopTiles().clear();
+		overlay.updateTopTiles(Collections.emptyList());
 		overlayManager.remove(overlay);
 	}
 
@@ -67,7 +67,7 @@ public class afkspotPlugin extends Plugin
 		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
 		{
 			tileDensity.clear();
-			overlay.getTopTiles().clear();
+			overlay.updateTopTiles(Collections.emptyList());
 		}
 	}
 


### PR DESCRIPTION
Converts the current $O(n \cdot log(n))$ algorithm to $O(n \cdot log(k))$ via priority heap (where $n$ is `tileDensity.size()`, $k$ is `afkspotConfig#numberOfTiles`, and $k \ll n$).

This PR also decreases memory allocations: `getCachedNPCs` avoids creating an intermediate list; `HashSet` is *only* created if `tileDensity` doesn't contain the `WorldPoint`; `Stream` is avoided; `getTopTiles` only uses $O(k)$ space.

Note: Technically the average time complexity can be further optimized to $O(n)$ via quickselect, but worst-case would be $O(n^2)$ (random pivots or Floyd-Rivest offer improvements) and space complexity would increase.
