### PR TITLE
perf: make npc loop linear again

### DIFF
--- a/src/main/java/com/afkspot/AfkSpotConfig.java
+++ b/src/main/java/com/afkspot/AfkSpotConfig.java
@@ -23,7 +23,7 @@ public interface AfkSpotConfig extends Config
 	@ConfigItem(
 			keyName = "npcNames",
 			name = "NPC Names",
-			description = "Specify the names of the NPCs to highlight tiles for, separated by a comma",
+			description = "Specify the names of the NPCs to highlight tiles for, separated by a comma or new line",
 			position = 2
 	)
 	default String npcNames()

--- a/src/main/java/com/afkspot/AfkSpotPlugin.java
+++ b/src/main/java/com/afkspot/AfkSpotPlugin.java
@@ -60,6 +60,7 @@ public class AfkSpotPlugin extends Plugin
 	protected void startUp()
 	{
 		log.info("AFK Spot Finder started!");
+		parseFilters(config.npcNames());
 		overlayManager.add(overlay);
 	}
 
@@ -69,6 +70,7 @@ public class AfkSpotPlugin extends Plugin
 		log.info("AFK Spot Finder stopped!");
 		this.region = this.plane = 0;
 		this.clear();
+		this.npcNameFilters.clear();
 		overlayManager.remove(overlay);
 	}
 
@@ -132,12 +134,7 @@ public class AfkSpotPlugin extends Plugin
 
 		if (event.getKey().equals("npcNames")) {
 			// Update npcNameFilters
-			npcNameFilters.clear();
-			DELIM.splitAsStream(event.getNewValue())
-				.filter(StringUtils::isNotBlank)
-				.map(String::trim)
-				.map(String::toLowerCase)
-				.forEach(npcNameFilters::add);
+			this.parseFilters(event.getNewValue());
 
 			// Clear the tileDensity map and the overlay when the NPC name is changed
 			this.clear();
@@ -148,6 +145,16 @@ public class AfkSpotPlugin extends Plugin
 	{
 		tileDensity.clear();
 		overlay.updateTopTiles(Collections.emptyList());
+	}
+
+	private void parseFilters(String npcNames)
+	{
+		npcNameFilters.clear();
+		DELIM.splitAsStream(npcNames)
+			.filter(StringUtils::isNotBlank)
+			.map(String::trim)
+			.map(String::toLowerCase)
+			.forEach(npcNameFilters::add);
 	}
 
 	@Provides

--- a/src/main/java/com/afkspot/AfkSpotPlugin.java
+++ b/src/main/java/com/afkspot/AfkSpotPlugin.java
@@ -14,18 +14,18 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Slf4j
 @PluginDescriptor(
@@ -36,6 +36,7 @@ import java.util.Set;
 public class AfkSpotPlugin extends Plugin
 {
 	private static final Comparator<Map.Entry<WorldPoint, Set<Integer>>> COMPARATOR = Comparator.comparingInt(e -> e.getValue().size());
+	private static final Pattern DELIM = Pattern.compile("[,;\\n]");
 
 	@Inject
 	private Client client;
@@ -48,6 +49,8 @@ public class AfkSpotPlugin extends Plugin
 
 	@Inject
 	private OverlayManager overlayManager;
+
+	private final Set<String> npcNameFilters = Collections.synchronizedSet(new HashSet<>());
 
 	private final Map<WorldPoint, Set<Integer>> tileDensity = new HashMap<>();
 	private int region = 0;
@@ -96,8 +99,6 @@ public class AfkSpotPlugin extends Plugin
 			this.clear();
 		}
 
-		List<String> npcNameFilter = Arrays.asList(config.npcNames().split(","));
-
 		NPC[] npcs = client.getCachedNPCs();
 		int n = npcs.length;
 		for (int index = 0; index < n; index++)
@@ -110,7 +111,8 @@ public class AfkSpotPlugin extends Plugin
 			}
 
 			// Skip the NPC if its name doesn't match the specified name
-			if (!npcNameFilter.isEmpty() && npcNameFilter.stream().noneMatch(name -> name.trim().equalsIgnoreCase(npc.getName())))
+			String name = npc.getName();
+			if (!npcNameFilters.isEmpty() && (name == null || !npcNameFilters.contains(name.toLowerCase())))
 			{
 				continue;
 			}
@@ -128,7 +130,15 @@ public class AfkSpotPlugin extends Plugin
 			return;
 		}
 
-		if (event.getKey().equals("npcName")) {
+		if (event.getKey().equals("npcNames")) {
+			// Update npcNameFilters
+			npcNameFilters.clear();
+			DELIM.splitAsStream(event.getNewValue())
+				.filter(StringUtils::isNotBlank)
+				.map(String::trim)
+				.map(String::toLowerCase)
+				.forEach(npcNameFilters::add);
+
 			// Clear the tileDensity map and the overlay when the NPC name is changed
 			this.clear();
 		}


### PR DESCRIPTION
* Fix: reflect new key name (`npcName` => `npcNames`) in `ConfigChanged` handler
* Performance: Store (trimmed, lowercase) npc names to a `HashSet` so checking for match is $O(1)$ instead of $O(m)$ (now the npc loop is $O(n)$ again, instead of $O(n \cdot m)$ with stream overhead)
* Feature: Allow more delimiter characters than `,`
