### PR TITLE
refactor: improve thread safety

### DIFF
--- a/src/main/java/com/afkspot/AfkSpotPlugin.java
+++ b/src/main/java/com/afkspot/AfkSpotPlugin.java
@@ -167,10 +167,10 @@ public class AfkSpotPlugin extends Plugin
 		clientThread.invoke(() -> {
 			npcNameFilters.clear();
 			DELIM.splitAsStream(npcNames)
-							.filter(StringUtils::isNotBlank)
-							.map(String::trim)
-							.map(String::toLowerCase)
-							.forEach(npcNameFilters::add);
+				.filter(StringUtils::isNotBlank)
+				.map(String::trim)
+				.map(String::toLowerCase)
+				.forEach(npcNameFilters::add);
 		});
 	}
 


### PR DESCRIPTION
Ensure any events triggered by swing UI thread are forwarded to the client thread so there are no concurrent modifications to `tileDensity`/`npcNameFilters` (which also lets us remove synchronization on `npcNameFilters`)
